### PR TITLE
WebRtcMediaStream buffer with specified length

### DIFF
--- a/org/ortc/WebRtcMediaStream.cc
+++ b/org/ortc/WebRtcMediaStream.cc
@@ -276,6 +276,7 @@ namespace Org
         static_cast<int>(destWidth),
         static_cast<int>(destHeight));
 
+	  buffer->SetCurrentLength(destMediaBufferSize);
       *sample = spSample.Detach();
       return S_OK;
     }


### PR DESCRIPTION
I am recording the peer video MediaSource to a mp4 and the buffer length needs to be specified to add the frames to a SinkWritter.